### PR TITLE
Change `console.setEndpoint()` to `fastly.getLogger()`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,9 @@
 addEventListener('fetch', async function handleRequest(event) {
   
   // NOTE: By default, console messages are sent to stdout (and stderr for `console.error`).
-  // To send them to a logging endpoint instead, use `console.setEndpoint:
-  // console.setEndpoint("my-logging-endpoint");
+  // To send them to a logging endpoint instead, use `fastly.getLogger()` to get a Logger instance:
+  // const logger = fastly.getLogger("my-logging-endpoint-name");
+  // logger.log("log message");
 
   // Get the client request from the event
   let req = event.request;

--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,8 @@
 // synthetic responses.
 addEventListener('fetch', async function handleRequest(event) {
   
-  // NOTE: By default, console messages are sent to stdout (and stderr for `console.error`).
-  // To send them to a logging endpoint instead, use `fastly.getLogger()` to get a Logger instance:
+  // Send logs to your custom logging endpoint
+  // https://developer.fastly.com/learning/compute/javascript/#logging
   // const logger = fastly.getLogger("my-logging-endpoint-name");
   // logger.log("log message");
 


### PR DESCRIPTION
https://js-compute-reference-docs.edgecompute.app/interfaces/fastly.html#getlogger

https://js-compute-reference-docs.edgecompute.app/interfaces/logger.html

I'll make a separate PR to update: https://developer.fastly.com/learning/compute/javascript/#logging