### PR TITLE
Remove --skip-pkg so it will deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "prebuild": "webpack",
-    "build": "js-compute-runtime --skip-pkg bin/index.js bin/main.wasm",
+    "build": "js-compute-runtime bin/index.js bin/main.wasm",
     "deploy": "npm run build && fastly compute deploy"
   }
 }


### PR DESCRIPTION
`--skip-pkg` causes the .tar.gz file to not be created, meaning deployments will always fail here.