### PR TITLE
Remove URL polyfill from webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,8 +28,5 @@ module.exports = {
     // Polyfills go here.
     // Used for, e.g., any cross-platform WHATWG, 
     // or core nodejs modules needed for your application.
-    new webpack.ProvidePlugin({
-      URL: "core-js/web/url",
-    }),
   ],
 };


### PR DESCRIPTION
We now have a native URL implementation, so the polyfill isn't needed anymore.