### PR TITLE
Updated @fastly/js-compute to 0.2.4

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,15 +1,14 @@
 {
   "name": "compute-starter-kit-javascript-default",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "compute-starter-kit-javascript-default",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "@fastly/js-compute": "^0.2.2"
+        "@fastly/js-compute": "^0.2.4"
       },
       "devDependencies": {
         "core-js": "^3.19.1",
@@ -30,9 +29,9 @@
       }
     },
     "node_modules/@fastly/js-compute": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-0.2.2.tgz",
-      "integrity": "sha512-J+ur7IyRnQrQBL4Nd3XVHxujPBcJ8a7YFfA6PiOd5qZqgA/7trFMMjVNpScVnvwDi4std6tnGxZp+axjI/jXMw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-0.2.4.tgz",
+      "integrity": "sha512-2e26D/2FiIF7W0eahvlp7NAoLwKTNdMi75W9vjaNbpUf2RPiYS0TkNvp5zJ4QlYF7h55ocKE4oM8iTTDYXfmZA==",
       "bin": {
         "js-compute-runtime": "js-compute-runtime-cli.js"
       }
@@ -1373,9 +1372,9 @@
       "dev": true
     },
     "@fastly/js-compute": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-0.2.2.tgz",
-      "integrity": "sha512-J+ur7IyRnQrQBL4Nd3XVHxujPBcJ8a7YFfA6PiOd5qZqgA/7trFMMjVNpScVnvwDi4std6tnGxZp+axjI/jXMw=="
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-0.2.4.tgz",
+      "integrity": "sha512-2e26D/2FiIF7W0eahvlp7NAoLwKTNdMi75W9vjaNbpUf2RPiYS0TkNvp5zJ4QlYF7h55ocKE4oM8iTTDYXfmZA=="
     },
     "@types/eslint": {
       "version": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compute-starter-kit-javascript-default",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "src/index.js",
   "repository": {
     "type": "git",
@@ -21,7 +21,7 @@
     "webpack-cli": "^4.9.1"
   },
   "dependencies": {
-    "@fastly/js-compute": "^0.2.2"
+    "@fastly/js-compute": "^0.2.4"
   },
   "scripts": {
     "prebuild": "webpack",


### PR DESCRIPTION
similar to #20 

This bumps `@fastly/js-compute` to the lastest version, 0.2.4: https://www.npmjs.com/package/@fastly/js-compute 😄 🎉 