### PR TITLE
Add Types reference

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,6 @@
 //! Default Compute@Edge template program.
+
+/// <reference types="@fastly/js-compute" />
 import welcomePage from "./welcome-to-compute@edge.html";
 
 // The entry point for your application.


### PR DESCRIPTION
As we suggest in our Learning page at https://developer.fastly.com/learning/compute/javascript/#developer-experience, we should reference the Types file inside the `index.js` file.

```javascript
/// <reference types="@fastly/js-compute" />
```

This helps all IDEs that understand types, and should hurt nobody. Also, this library is already referenced in `package.json`.
