### PR TITLE
Use JS SDK 0.5.2, allow Node >= 16

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -17,7 +17,7 @@
         "webpack-cli": "^4.9.1"
       },
       "engines": {
-        "node": "^16"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@fastly/js-compute": "^0.5.0"
+        "@fastly/js-compute": "^0.5.2"
       },
       "devDependencies": {
         "core-js": "^3.19.1",
@@ -30,9 +30,9 @@
       }
     },
     "node_modules/@fastly/js-compute": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-0.5.1.tgz",
-      "integrity": "sha512-TK04EGTpkrwQGxM5veDKVqvMCmALS/vyjb2UbpHPMS+yL/lCPnqvNiJ6UYVToBZoH5MwMEIwarZ0DPU5xDPTdQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-0.5.2.tgz",
+      "integrity": "sha512-Dr0aw55M05kuRL9+awRtvJqu3Wo1kmxbuVqtX7Y9ke3LNKsmjDwf7T4WOAO4EQYIwtDGLVP8uIq4RxFxl5frlA==",
       "dependencies": {
         "typedoc-loopingz-theme": "^1.1.3"
       },
@@ -1593,9 +1593,9 @@
       "dev": true
     },
     "@fastly/js-compute": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-0.5.1.tgz",
-      "integrity": "sha512-TK04EGTpkrwQGxM5veDKVqvMCmALS/vyjb2UbpHPMS+yL/lCPnqvNiJ6UYVToBZoH5MwMEIwarZ0DPU5xDPTdQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-0.5.2.tgz",
+      "integrity": "sha512-Dr0aw55M05kuRL9+awRtvJqu3Wo1kmxbuVqtX7Y9ke3LNKsmjDwf7T4WOAO4EQYIwtDGLVP8uIq4RxFxl5frlA==",
       "requires": {
         "typedoc-loopingz-theme": "^1.1.3"
       }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "webpack-cli": "^4.9.1"
   },
   "dependencies": {
-    "@fastly/js-compute": "^0.5.1"
+    "@fastly/js-compute": "^0.5.2"
   },
   "scripts": {
     "prebuild": "webpack",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://developer.fastly.com/solutions/starters/compute-starter-kit-javascript-default",
   "engines": {
-    "node": "^16"
+    "node": ">=16.0.0"
   },
   "devDependencies": {
     "core-js": "^3.19.1",


### PR DESCRIPTION
This PR updates js SDK to 0.5.2

Allow versions of node >= 16
(note that this node version only matters for running Webpack to build the worker bundle. the version of node is unrelated to the actual Wasm that runs.)
