### PR TITLE
Modernize the starter kit

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,14 +9,116 @@
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
-        "@fastly/js-compute": "^1.3.2"
+        "@fastly/js-compute": "^1.5.1"
       },
       "devDependencies": {
-        "webpack": "^5.75.0",
+        "webpack": "^5.76.2",
         "webpack-cli": "^5.0.1"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/regjsgen": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
+    },
+    "node_modules/@bytecodealliance/componentize-js": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.0.1.tgz",
+      "integrity": "sha512-sfQwMMfWZcMJ70cdMm0QnasTTXRM/LGgEzTeBbHPnJE/YQpqMEi4TsjbyGCVV9GLzMC0mRfS8aX8vlkYVhwJcw==",
+      "dependencies": {
+        "@bytecodealliance/jco": "^0.4.0",
+        "@jakechampion/wizer": "^1.6.0"
+      }
+    },
+    "node_modules/@bytecodealliance/jco": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-0.4.2.tgz",
+      "integrity": "sha512-adeezw3wQhuGzEUcc4fZ/Vm9rn7Yp1p+0fbgg7TWfNuVrgbwMN3Me2BVAQqEwfKf3x/jfgbU1D0neFsu83eqYQ==",
+      "dependencies": {
+        "@bytecodealliance/componentize-js": "^0.0.1"
+      },
+      "bin": {
+        "jco": "cli.mjs"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer/-/wizer-1.6.1-beta.4.tgz",
+      "integrity": "sha512-afgV4lyYVMBN/9/yNDgYGTn92D7VrqS0yTZ3WZgDyDTiOWjmSuQimEiX+VzCiYjF9GXsKwzCY1FEOu1pY2Evgw==",
+      "bin": {
+        "wizer": "wizer.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@bytecodealliance/wizer-darwin-arm64": "1.6.1-beta.4",
+        "@bytecodealliance/wizer-darwin-x64": "1.6.1-beta.4",
+        "@bytecodealliance/wizer-linux-x64": "1.6.1-beta.4",
+        "@bytecodealliance/wizer-win32-x64": "1.6.1-beta.4"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-darwin-arm64": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-darwin-arm64/-/wizer-darwin-arm64-1.6.1-beta.4.tgz",
+      "integrity": "sha512-NyleEH0GKBqS0DCuKceY3a2ZxF/aNzYa68swbKKljSFh6uo/3Cqr/U5/SuTxval6/VwtZ1eEzRPaLbLlUE5r4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "wizer-darwin-arm64": "wizer"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-darwin-x64": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-darwin-x64/-/wizer-darwin-x64-1.6.1-beta.4.tgz",
+      "integrity": "sha512-2s8HPLrttAyYUJNHQlLVi3rDGlnk9IzEJTbw0DApfpVnCZZ1aTLt6MXTIBeOYo9si5Q4cqyDHT5bAoNZvJTk9A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "wizer-darwin-x64": "wizer"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-linux-x64": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-linux-x64/-/wizer-linux-x64-1.6.1-beta.4.tgz",
+      "integrity": "sha512-S+oYRGGveuPLtiI6V7SQpZHhw43asLArC+fGrJRQ3OsHs8aj/IVusRLVYgWfKw1HtZm9iIWrjH9WYO6BWak4eQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "wizer-linux-x64": "wizer"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-win32-x64": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-win32-x64/-/wizer-win32-x64-1.6.1-beta.4.tgz",
+      "integrity": "sha512-NxqrLqFnaMyldkN7lBVS+Em23f84/RKrHjBXt9WnZK2RtJjvwoCXr+so6+qfj4f1K9BhIZ8UaBfYwqPvtLOcZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "wizer-win32-x64": "wizer"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -29,13 +131,14 @@
       }
     },
     "node_modules/@fastly/js-compute": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-1.3.2.tgz",
-      "integrity": "sha512-SvWaa2Qf05AKeNejW55/5T3ROd+mO7mRQh/wBNH29OyqJOi4lrC9D3uCWJMjdyyi4jxrL6ux8vWGJglFCBRoyQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-1.5.1.tgz",
+      "integrity": "sha512-PXTZtB4cQziFyOs4KPpZ9ZW6sOOYv2PslXH9HVPDkDCo+G+Q+HcnKKc1giGPGR/NipqVkCugkaNynaVHMCrijw==",
       "dependencies": {
-        "@jakechampion/wizer": "^1.6.0",
+        "@bytecodealliance/jco": "^0.4.1",
+        "@bytecodealliance/wizer": "^1.6.1-beta.4",
         "esbuild": "^0.15.16",
-        "js-component-tools": "0.2.2",
+        "regexpu-core": "^5.3.1",
         "tree-sitter": "^0.20.1",
         "tree-sitter-javascript": "^0.19.0"
       },
@@ -43,8 +146,8 @@
         "js-compute-runtime": "js-compute-runtime-cli.js"
       },
       "engines": {
-        "node": "16 - 18",
-        "npm": "^8"
+        "node": "16 - 19",
+        "npm": "^8 || ^9"
       }
     },
     "node_modules/@jakechampion/wizer": {
@@ -68,9 +171,13 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@jakechampion/wizer-darwin-arm64/-/wizer-darwin-arm64-1.6.0.tgz",
       "integrity": "sha512-bQdIPdR+Ye0GiNdirVhx0kx14oY2uzwXfh/2dDgteBdcb7mDubzKbdt3ROMyV1UFRVhOtqbthZNk7qLBB6Occg==",
-      "cpu": ["arm64"],
+      "cpu": [
+        "arm64"
+      ],
       "optional": true,
-      "os": ["darwin"],
+      "os": [
+        "darwin"
+      ],
       "bin": {
         "wizer-darwin-arm64": "wizer"
       }
@@ -79,9 +186,13 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@jakechampion/wizer-darwin-x64/-/wizer-darwin-x64-1.6.0.tgz",
       "integrity": "sha512-b+hdpZbhilsroSJU4Z2t+qj9lz3lr3M0TTyM8vlHODP0j8ZabZwPM8314wuSdSrHM5fZ9qIAO2Q94AUBBOeuRA==",
-      "cpu": ["x64"],
+      "cpu": [
+        "x64"
+      ],
       "optional": true,
-      "os": ["darwin"],
+      "os": [
+        "darwin"
+      ],
       "bin": {
         "wizer-darwin-x64": "wizer"
       }
@@ -90,9 +201,13 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@jakechampion/wizer-linux-x64/-/wizer-linux-x64-1.6.0.tgz",
       "integrity": "sha512-nOH/wwoN/jaLYBKyCnEQJtqEOrSuXMOWIdnh/vAp5w4sFXuyelyZY0k6g9b8puzLOyXJTrUoYfhHyf2vdLGlxQ==",
-      "cpu": ["x64"],
+      "cpu": [
+        "x64"
+      ],
       "optional": true,
-      "os": ["linux"],
+      "os": [
+        "linux"
+      ],
       "bin": {
         "wizer-linux-x64": "wizer"
       }
@@ -101,9 +216,13 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@jakechampion/wizer-win32-x64/-/wizer-win32-x64-1.6.0.tgz",
       "integrity": "sha512-9xzpraJIhLdOnXTC1DjxjyfV52BBlAZTTAlpnE04GxVRvRGZ6wPi/RdACkg3inAfeTP7A/bTq3BJLql/Hansdw==",
-      "cpu": ["x64"],
+      "cpu": [
+        "x64"
+      ],
       "optional": true,
-      "os": ["win32"],
+      "os": [
+        "win32"
+      ],
       "bin": {
         "wizer-win32-x64": "wizer"
       }
@@ -1090,12 +1209,12 @@
         "node": ">= 10.13.0"
       }
     },
-    "node_modules/js-component-tools": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/js-component-tools/-/js-component-tools-0.2.2.tgz",
-      "integrity": "sha512-+DorgW2JyOf3Qja35wtw0VQYkcdo4tkInapJ4xlPJXXW49RhEdNMzX/PoHKC5nS7AhV1VBweA1gmYOIYUOXDLw==",
+    "node_modules/jsesc": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
       "bin": {
-        "jsct": "cli.mjs"
+        "jsesc": "bin/jsesc"
       }
     },
     "node_modules/json-parse-even-better-errors": {
@@ -1430,6 +1549,49 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="
+    },
+    "node_modules/regenerate-unicode-properties": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.0.tgz",
+      "integrity": "sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==",
+      "dependencies": {
+        "regenerate": "^1.4.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/regexpu-core": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.2.tgz",
+      "integrity": "sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==",
+      "dependencies": {
+        "@babel/regjsgen": "^0.8.0",
+        "regenerate": "^1.4.2",
+        "regenerate-unicode-properties": "^10.1.0",
+        "regjsparser": "^0.9.1",
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/regjsparser": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
+      "integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
+      "dependencies": {
+        "jsesc": "~0.5.0"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
       }
     },
     "node_modules/resolve": {
@@ -1798,6 +1960,42 @@
         "node": "*"
       }
     },
+    "node_modules/unicode-canonical-property-names-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
+      "dependencies": {
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-value-ecmascript": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-property-aliases-ecmascript": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
@@ -1852,9 +2050,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.2.tgz",
+      "integrity": "sha512-Th05ggRm23rVzEOlX8y67NkYCHa9nTNcwHPBhdg+lKG+mtiW7XgggjAeeLnADAe7mLjJ6LUNfgHAuRRh+Z6J7w==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -2010,6 +2208,63 @@
     }
   },
   "dependencies": {
+    "@babel/regjsgen": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
+    },
+    "@bytecodealliance/componentize-js": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.0.1.tgz",
+      "integrity": "sha512-sfQwMMfWZcMJ70cdMm0QnasTTXRM/LGgEzTeBbHPnJE/YQpqMEi4TsjbyGCVV9GLzMC0mRfS8aX8vlkYVhwJcw==",
+      "requires": {
+        "@bytecodealliance/jco": "^0.4.0",
+        "@jakechampion/wizer": "^1.6.0"
+      }
+    },
+    "@bytecodealliance/jco": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-0.4.2.tgz",
+      "integrity": "sha512-adeezw3wQhuGzEUcc4fZ/Vm9rn7Yp1p+0fbgg7TWfNuVrgbwMN3Me2BVAQqEwfKf3x/jfgbU1D0neFsu83eqYQ==",
+      "requires": {
+        "@bytecodealliance/componentize-js": "^0.0.1"
+      }
+    },
+    "@bytecodealliance/wizer": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer/-/wizer-1.6.1-beta.4.tgz",
+      "integrity": "sha512-afgV4lyYVMBN/9/yNDgYGTn92D7VrqS0yTZ3WZgDyDTiOWjmSuQimEiX+VzCiYjF9GXsKwzCY1FEOu1pY2Evgw==",
+      "requires": {
+        "@bytecodealliance/wizer-darwin-arm64": "1.6.1-beta.4",
+        "@bytecodealliance/wizer-darwin-x64": "1.6.1-beta.4",
+        "@bytecodealliance/wizer-linux-x64": "1.6.1-beta.4",
+        "@bytecodealliance/wizer-win32-x64": "1.6.1-beta.4"
+      }
+    },
+    "@bytecodealliance/wizer-darwin-arm64": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-darwin-arm64/-/wizer-darwin-arm64-1.6.1-beta.4.tgz",
+      "integrity": "sha512-NyleEH0GKBqS0DCuKceY3a2ZxF/aNzYa68swbKKljSFh6uo/3Cqr/U5/SuTxval6/VwtZ1eEzRPaLbLlUE5r4w==",
+      "optional": true
+    },
+    "@bytecodealliance/wizer-darwin-x64": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-darwin-x64/-/wizer-darwin-x64-1.6.1-beta.4.tgz",
+      "integrity": "sha512-2s8HPLrttAyYUJNHQlLVi3rDGlnk9IzEJTbw0DApfpVnCZZ1aTLt6MXTIBeOYo9si5Q4cqyDHT5bAoNZvJTk9A==",
+      "optional": true
+    },
+    "@bytecodealliance/wizer-linux-x64": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-linux-x64/-/wizer-linux-x64-1.6.1-beta.4.tgz",
+      "integrity": "sha512-S+oYRGGveuPLtiI6V7SQpZHhw43asLArC+fGrJRQ3OsHs8aj/IVusRLVYgWfKw1HtZm9iIWrjH9WYO6BWak4eQ==",
+      "optional": true
+    },
+    "@bytecodealliance/wizer-win32-x64": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-win32-x64/-/wizer-win32-x64-1.6.1-beta.4.tgz",
+      "integrity": "sha512-NxqrLqFnaMyldkN7lBVS+Em23f84/RKrHjBXt9WnZK2RtJjvwoCXr+so6+qfj4f1K9BhIZ8UaBfYwqPvtLOcZQ==",
+      "optional": true
+    },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -2017,13 +2272,14 @@
       "dev": true
     },
     "@fastly/js-compute": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-1.3.2.tgz",
-      "integrity": "sha512-SvWaa2Qf05AKeNejW55/5T3ROd+mO7mRQh/wBNH29OyqJOi4lrC9D3uCWJMjdyyi4jxrL6ux8vWGJglFCBRoyQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-1.5.1.tgz",
+      "integrity": "sha512-PXTZtB4cQziFyOs4KPpZ9ZW6sOOYv2PslXH9HVPDkDCo+G+Q+HcnKKc1giGPGR/NipqVkCugkaNynaVHMCrijw==",
       "requires": {
-        "@jakechampion/wizer": "^1.6.0",
+        "@bytecodealliance/jco": "^0.4.1",
+        "@bytecodealliance/wizer": "^1.6.1-beta.4",
         "esbuild": "^0.15.16",
-        "js-component-tools": "0.2.2",
+        "regexpu-core": "^5.3.1",
         "tree-sitter": "^0.20.1",
         "tree-sitter-javascript": "^0.19.0"
       }
@@ -2039,6 +2295,12 @@
         "@jakechampion/wizer-win32-x64": "1.6.0"
       }
     },
+    "@jakechampion/wizer-darwin-arm64": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jakechampion/wizer-darwin-arm64/-/wizer-darwin-arm64-1.6.0.tgz",
+      "integrity": "sha512-bQdIPdR+Ye0GiNdirVhx0kx14oY2uzwXfh/2dDgteBdcb7mDubzKbdt3ROMyV1UFRVhOtqbthZNk7qLBB6Occg==",
+      "optional": true
+    },
     "@jakechampion/wizer-darwin-x64": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@jakechampion/wizer-darwin-x64/-/wizer-darwin-x64-1.6.0.tgz",
@@ -2049,6 +2311,12 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@jakechampion/wizer-linux-x64/-/wizer-linux-x64-1.6.0.tgz",
       "integrity": "sha512-nOH/wwoN/jaLYBKyCnEQJtqEOrSuXMOWIdnh/vAp5w4sFXuyelyZY0k6g9b8puzLOyXJTrUoYfhHyf2vdLGlxQ==",
+      "optional": true
+    },
+    "@jakechampion/wizer-win32-x64": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jakechampion/wizer-win32-x64/-/wizer-win32-x64-1.6.0.tgz",
+      "integrity": "sha512-9xzpraJIhLdOnXTC1DjxjyfV52BBlAZTTAlpnE04GxVRvRGZ6wPi/RdACkg3inAfeTP7A/bTq3BJLql/Hansdw==",
       "optional": true
     },
     "@jridgewell/gen-mapping": {
@@ -2808,10 +3076,10 @@
         "supports-color": "^8.0.0"
       }
     },
-    "js-component-tools": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/js-component-tools/-/js-component-tools-0.2.2.tgz",
-      "integrity": "sha512-+DorgW2JyOf3Qja35wtw0VQYkcdo4tkInapJ4xlPJXXW49RhEdNMzX/PoHKC5nS7AhV1VBweA1gmYOIYUOXDLw=="
+    "jsesc": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA=="
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -3081,6 +3349,40 @@
         "resolve": "^1.20.0"
       }
     },
+    "regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="
+    },
+    "regenerate-unicode-properties": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.0.tgz",
+      "integrity": "sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==",
+      "requires": {
+        "regenerate": "^1.4.2"
+      }
+    },
+    "regexpu-core": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.2.tgz",
+      "integrity": "sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==",
+      "requires": {
+        "@babel/regjsgen": "^0.8.0",
+        "regenerate": "^1.4.2",
+        "regenerate-unicode-properties": "^10.1.0",
+        "regjsparser": "^0.9.1",
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.1.0"
+      }
+    },
+    "regjsparser": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
+      "integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
+      "requires": {
+        "jsesc": "~0.5.0"
+      }
+    },
     "resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -3339,6 +3641,30 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ=="
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA=="
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w=="
+    },
     "update-browserslist-db": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
@@ -3374,9 +3700,9 @@
       }
     },
     "webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.2.tgz",
+      "integrity": "sha512-Th05ggRm23rVzEOlX8y67NkYCHa9nTNcwHPBhdg+lKG+mtiW7XgggjAeeLnADAe7mLjJ6LUNfgHAuRRh+Z6J7w==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",

--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@fastly/js-compute": "^1.3.2"
+    "@fastly/js-compute": "^1.5.1"
   },
   "devDependencies": {
-    "webpack": "^5.75.0",
+    "webpack": "^5.76.2",
     "webpack-cli": "^5.0.1"
   },
   "scripts": {
     "prebuild": "webpack",
     "build": "js-compute-runtime bin/index.js bin/main.wasm",
-    "deploy": "npm run build && fastly compute deploy"
+    "deploy": "fastly compute publish"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 //! Default Compute@Edge template program.
 
 /// <reference types="@fastly/js-compute" />
-
 // import { CacheOverride } from "fastly:cache-override";
 // import { Logger } from "fastly:logger";
+import { env } from "fastly:env";
 import { includeBytes } from "fastly:experimental";
 
 // Load a static file as a Uint8Array at compile time.
@@ -21,7 +21,7 @@ addEventListener("fetch", (event) => event.respondWith(handleRequest(event)));
 
 async function handleRequest(event) {
   // Log service version
-  console.log("FASTLY_SERVICE_VERSION:", fastly.env.get('FASTLY_SERVICE_VERSION' || ''));
+  console.log("FASTLY_SERVICE_VERSION:", env('FASTLY_SERVICE_VERSION') || 'local');
   
   // Get the client request.
   let req = event.request;


### PR DESCRIPTION
PR suggests:

* Update to js-compute 1.5.1
* Update to Webpack 5.76
* Fix use of env to the recommended namespaced version
* Fix env call
* Fix deploy script to use fastly compute publish