### PR TITLE
Filtering requests without mentioning purge

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ async function handleRequest(event) {
   let req = event.request;
 
   // Filter requests that have unexpected methods.
-  if (!["HEAD", "GET", "PURGE"].includes(req.method)) {
+  if (["POST", "PUT", "PATCH", "DELETE"].includes(req.method)) {
     return new Response("This method is not allowed", {
       status: 405,
     });


### PR DESCRIPTION
Since we want to allow purge requests but not _encourage_ them, the method for filtering requests is being rewritten so as not to mention purging. The outcome of the method remains functionally the same, with HEAD, GET, and PURGE requests being let through and POST, PUT, PATCH, and DELETE being blocked. 