### PR TITLE
fix: hardcode the deploy button to this repository to avoid having to rely on referer header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Default Starter Kit for JavaScript
 
-[![Deploy to Fastly](https://deploy.edgecompute.app/button)](https://deploy.edgecompute.app/deploy)
+[![Deploy to Fastly](https://deploy.edgecompute.app/button)](https://deploy.edgecompute.app/fastly/compute-starter-kit-javascript-default)
 
 Get to know the Fastly Compute@Edge environment with a basic starter that demonstrates routing, simple synthetic responses and code comments that cover common patterns.
 


### PR DESCRIPTION
The referer header may not exist (Users and/or Websites can disable the referer header) - which causes the deploy button to not work (https://github.com/fastly/compute-starter-kit-javascript-default/issues/16). By hard-coding the path in the deploy link, we no longer will use the referer header.

Fixes https://github.com/fastly/compute-starter-kit-javascript-default/issues/16