### PR TITLE
Lower the supported NodeJS version from 18 or greater to only 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://developer.fastly.com/solutions/starters/compute-starter-kit-javascript-default",
   "engines": {
-    "node": ">=18.0.0"
+    "node": "^18.0.0"
   },
   "dependencies": {
     "@fastly/js-compute": "^1.5.1"


### PR DESCRIPTION
Node 19 is [not supported by tree-sitter yet](https://github.com/tree-sitter/node-tree-sitter/pull/127), and that is a dependency of `@fastly/js-compute`. Until tree-sitter works on Node 19, we should not list Node 19 as supported.