### PR TITLE
Tell webpack to not minimize the bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ const webpack = require("webpack");
 module.exports = {
   entry: "./src/index.js",
   optimization: {
-    minimize: true
+    minimize: false
   },
   target: "webworker",
   output: {


### PR DESCRIPTION
This change tells webpack to not minimize the JavaScript bundle as it makes debugging harder and does not make anything smaller or faster. All the parsing is done ahead of time when we compile to the Wasm file that gets uploaded to Fastly.