### PR TITLE
JS 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,22 +1,10 @@
 {
-  "name": "compute-starter-kit-javascript-default",
-  "version": "0.4.0",
   "main": "src/index.js",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/fastly/compute-starter-kit-javascript-default.git"
-  },
-  "author": "oss@fastly.com",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/fastly/compute-starter-kit-javascript-default/issues"
-  },
-  "homepage": "https://developer.fastly.com/solutions/starters/compute-starter-kit-javascript-default",
   "engines": {
     "node": "^18.0.0"
   },
   "dependencies": {
-    "@fastly/js-compute": "^3.0.0"
+    "@fastly/js-compute": "^3.1.0"
   },
   "devDependencies": {
     "webpack": "^5.78.0",


### PR DESCRIPTION
Remove unnecessary package metadata because it's wrong as soon as the customer clones the starter, plus starter kits do not support github issues, and the version has been stuck on 0.4.0 since forever.

Does webpack make use of `main`?  If not we should remove that too.